### PR TITLE
fix: compile properly on Ubuntu16.04

### DIFF
--- a/spyndra_gazebo/CMakeLists.txt
+++ b/spyndra_gazebo/CMakeLists.txt
@@ -116,8 +116,8 @@ catkin_package(
 ## Specify additional locations of header files
 ## Your package locations should be listed before other locations
 include_directories(
-# include
-# ${catkin_INCLUDE_DIRS}
+ include
+ ${catkin_INCLUDE_DIRS}
 )
 
 ## Declare a C++ library

--- a/spyndra_gazebo/package.xml
+++ b/spyndra_gazebo/package.xml
@@ -40,7 +40,10 @@
   <!-- Use test_depend for packages you need only for testing: -->
   <!--   <test_depend>gtest</test_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
-
+  <build_depend>roscpp</build_depend>
+  <build_depend>rospy</build_depend>
+  <run_depend>roscpp</run_depend>
+  <run_depend>rospy</run_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>


### PR DESCRIPTION
fix
Solve the problem that spyndra_gazebo cannot be compiled properly on Ubuntu16.04 and ROS Kinetic.